### PR TITLE
Fix Pulsar variable name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Copy this file to .env and customize values as needed
 
 # Pulsar connection
-PULSAR_URL=pulsar://pulsar:6650
+PULSAR_SERVICE_URL=pulsar://pulsar:6650
 PULSAR_ADMIN_URL=http://pulsar:8080
 PULSAR_TOPIC=logs/nginx/access
 

--- a/log_analytics_guide.md
+++ b/log_analytics_guide.md
@@ -49,7 +49,7 @@
 
 ```
 log-analytics-flink/
-├─ .env.example              # mẫu biến môi trường (PULSAR_URL, MINIO_ENDPOINT, FLINK_JOB_NAME...)
+├─ .env.example              # mẫu biến môi trường (PULSAR_SERVICE_URL, MINIO_ENDPOINT, FLINK_JOB_NAME...)
 ├─ compose/                  # Docker Compose configs
 │  ├─ docker-compose.yml     # build & run services chung
 │  └─ conf/                  # các file cấu hình dịch vụ


### PR DESCRIPTION
## Summary
- correct Pulsar environment variable name in `.env.example`
- update guide to reference `PULSAR_SERVICE_URL`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68708f244844832b82dc9c4ac01b5a84