### PR TITLE
Build Pulsar plugin from source

### DIFF
--- a/compose/conf/fluent-bit/Dockerfile
+++ b/compose/conf/fluent-bit/Dockerfile
@@ -1,5 +1,15 @@
 # Fluent Bit with custom configuration
+### Stage 1: build Pulsar output plugin from source
+FROM golang:1.22 AS builder
+
+WORKDIR /src
+RUN git clone --depth 1 https://github.com/transnano/fluent-bit-go-pulsar-output . \
+    && go build -buildmode=c-shared -o out_pulsar.so .
+
+### Stage 2: final Fluent Bit image
 FROM fluent/fluent-bit:2.2
+
+COPY --from=builder /src/out_pulsar.so /fluent-bit/out_pulsar.so
 
 
 
@@ -14,4 +24,4 @@ EXPOSE 2020
 # ENTRYPOINT ["/fluent-bit/bin/fluent-bit"]
 
 # Default command with our config
-CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf"]
+CMD ["/fluent-bit/bin/fluent-bit", "-e", "/fluent-bit/out_pulsar.so", "-c", "/fluent-bit/etc/fluent-bit.conf"]

--- a/compose/conf/fluent-bit/fluent-bit.conf
+++ b/compose/conf/fluent-bit/fluent-bit.conf
@@ -23,7 +23,7 @@
     Record      hostname ${HOSTNAME}
 
 [OUTPUT]
-    Name                pulsar
+    Name                pulsar-go
     Match               *
     Pulsar_Broker       pulsar://pulsar:6650
     Pulsar_Topic        persistent://public/default/logs-nginx-access

--- a/scripts/test-log-format.sh
+++ b/scripts/test-log-format.sh
@@ -3,7 +3,8 @@
 # Quick test script to generate a few sample log entries
 # Usage: ./test-log-format.sh
 
-LOG_FILE="../data/access.log"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_FILE="$SCRIPT_DIR/../data/access.log"
 
 echo "Generating sample log entries for testing..."
 


### PR DESCRIPTION
## Summary
- build Pulsar output plugin during Fluent Bit image build
- drop binary plugin from repo
- make test script work regardless of current directory

## Testing
- `./scripts/test-log-format.sh`


------
https://chatgpt.com/codex/tasks/task_b_687601b4f17c832ba0a462e09e651f5f